### PR TITLE
feat: add MulmoCast/GraphAI ideas and prune outdated entries

### DIFF
--- a/bootcamp/short-term-projects.md
+++ b/bootcamp/short-term-projects.md
@@ -2,6 +2,10 @@
 
 <!-- 新しいアイデアは上に追加。古いものは下の「古いアイデア（過去案）」セクションへ。 -->
 
+- MulmoCast を使った動画サービス／Podcast サービス／プレゼンテーションツール、その他 wow なツール
+- GraphAI の agent を追加する
+- GraphAI 本体の改良
+- GraphAI の graph／フローを簡単に作成するための補助ツール
 - BaaS（Firebase, Supabase など）を使って、非エンジニアがセキュアなプロジェクトを作れるようにサポートするツール（skill でも汎用ツールでも可）
 - MCP + AI + ffmpeg などを組み合わせて、無人もしくは簡単に動画編集できるツール／アプリ。長尺素材から切り出して YouTube 向けやショート動画化するもの
 
@@ -10,10 +14,6 @@
 ## 古いアイデア（過去案）
 
 - ai-pm
-- multi modal viewer
 
 - grapysのUI(Graph Flow)をコンポーネント化して、他でも簡単に使えるようにする
 - visionのテンプレート増やす
-- greedyなjson parser(code block, textから抽出）
-- greedyなjson parser(js的な{}, } も許容する。keyを""で囲まなくても良い
-- swipejsをモダンな環境に移植する


### PR DESCRIPTION
## Summary

新規アイデア4件を上部に追加し、古いアイデアから4件を削除。

### 追加（新規4件）
- MulmoCast を使った動画サービス／Podcast サービス／プレゼンテーションツール、その他 wow なツール
- GraphAI の agent を追加する
- GraphAI 本体の改良
- GraphAI の graph／フローを簡単に作成するための補助ツール

### 削除（古いアイデア from 過去案セクション）
- multi modal viewer
- greedy json parser（code block, text から抽出）
- greedy json parser（js 的な `{}`, `}` も許容）
- swipejs をモダン環境に移植

## User Prompt

以下の4件を新規アイデアとして追加:

- mulmocastを使った、動画サービス、podcastサービス、プレゼンテーションツール、その他wowなツール
- graphaiのagentの追加
- graphaiを改良
- graphaiのgraphやフローを簡単に作成するための補助ツール

加えて以下4件を削除:

- greedyなjson parser(code block, textから抽出）
- greedyなjson parser(js的な{}, } も許容する。keyを""で囲まなくても良い
- swipejsをモダンな環境に移植する
- multi modal viewer