### PR TITLE
docs: anon key を Publishable key に統一（付録A・用語集）

### DIFF
--- a/development/twitter_supabase/apx-a-supabase-setup.md
+++ b/development/twitter_supabase/apx-a-supabase-setup.md
@@ -27,7 +27,7 @@ nav_exclude: true
 
 3. **URLと鍵（キー）を控える。** 左メニューの「**Project Settings**（歯車アイコン）」→「**API**」を開きます。次の2つを、あとでコードに貼るためにコピーしておきます。
    - **Project URL**（`https://xxxx.supabase.co` の形）
-   - **anon public** key（`anon` `public` と書かれた長い文字列）
+   - **Publishable key**（`sb_publishable_...` から始まる文字列）。フロント（ブラウザのコード）に置いてよい公開鍵です。
 
 4. **作業する2つの場所を確認する。** 左メニューに、これからよく使う場所が2つあります。
    - **Table Editor** … 表（テーブル）を**画面（GUI）で作ったり中身を見たりする**場所。
@@ -38,14 +38,14 @@ nav_exclude: true
 
    ```js
    import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
-   const supabase = createClient('https://xxxx.supabase.co', 'ここに anon public key');
+   const supabase = createClient('https://xxxx.supabase.co', 'ここに publishable key');
    ```
 
    **1行ずつ読むと：**
    - `import { createClient } from '...'` … Supabaseを使うための道具 `createClient` を、CDN（ネット上の配布先）から読み込む。
    - `createClient( ... )` … その道具で、Supabaseとやり取りする**クライアント（窓口）を作る**。
    - 第1引数 `'https://xxxx.supabase.co'` … 手順3の **Project URL**（あなたの値に置きかえる）。
-   - 第2引数 `'ここに anon public key'` … 手順3の **anon public key**（あなたの値に置きかえる）。
+   - 第2引数 `'ここに publishable key'` … 手順3の **Publishable key**（あなたの値に置きかえる）。
    - 以後は、本編のコードで出てくる **この `supabase` を使って**保存・取得を行います。
 
 ---
@@ -54,7 +54,7 @@ nav_exclude: true
 
 鍵（キー）には2種類あり、**扱い方がまったく違います**。
 
-- **anon public key** … **フロント（ブラウザのコード）に置いてOK**です。名前のとおり「公開してよい鍵」。ただし「誰でも何でもできる」という意味ではなく、**RLS（行レベルセキュリティ）で守る前提**だから安全に置けます。RLSの設定は第4章で行います。
+- **Publishable key** … **フロント（ブラウザのコード）に置いてOK**です。名前のとおり「公開してよい鍵」。ただし「誰でも何でもできる」という意味ではなく、**RLS（行レベルセキュリティ）で守る前提**だから安全に置けます。RLSの設定は第4章で行います。
 - **service_role key** … **全権限を持つ「マスターキー」**です。RLSも素通りします。**ぜったいにフロントや、GitHubなどの公開リポジトリに出さないでください**。これは**サーバー専用**で、本編の範囲では使いません。
 
 > ⚠️ `service_role` key をブラウザのコードに書いて公開すると、**他人にデータを全部読まれる・消される**おそれがあります。第10章「ありがちな失敗」とも関わる、重要な落とし穴です。
@@ -64,7 +64,7 @@ nav_exclude: true
 ## ⚠️ よくあるつまずき
 
 - **プロジェクトが「Paused（一時停止）」になっている** … 無料枠では、しばらく使わないとプロジェクトが自動で休止します。ダッシュボードに「Restore」や「Resume」が出ていたら押して、**再開**してから使いましょう。
-- **URLや鍵の貼り間違い** … `createClient(...)` でエラーが出るときは、**Project URL** と **anon key** を**もう一度コピーし直して**貼り付けます。よくあるのは、前後の空白が混じる・別の値を貼る、です。
+- **URLや鍵の貼り間違い** … `createClient(...)` でエラーが出るときは、**Project URL** と **Publishable key** を**もう一度コピーし直して**貼り付けます。よくあるのは、前後の空白が混じる・別の値を貼る、です。
 - **リージョンを遠くにして遅い** … 日本から使うなら **Tokyo** など近い場所を選びます。遠いリージョンだと、保存や取得のたびに**待ち時間が長く**なります。
 
 ---
@@ -72,7 +72,7 @@ nav_exclude: true
 ## 📝 ことばメモ
 
 - **Project URL**：あなたのSupabaseプロジェクトの住所（`https://xxxx.supabase.co`）。コードの第1引数に使う
-- **anon key（anon public key）**：**ブラウザに置いてよい鍵**。RLSで守る前提
+- **Publishable key**：**ブラウザに置いてよい鍵**（`sb_publishable_...`）。RLSで守る前提。以前は **anon key（anon public key）** と呼ばれ、既存プロジェクトでは今もその名称で表示される
 - **service_role key**：**全権限のマスターキー**。サーバー専用で、フロントや公開リポジトリに出さない
 - **Table Editor**：表（テーブル）を画面で作る・見る場所
 - **SQL Editor**：SQLを実行する場所（本編のSQLはここで実行）

--- a/development/twitter_supabase/apx-e-glossary.md
+++ b/development/twitter_supabase/apx-e-glossary.md
@@ -77,7 +77,7 @@ nav_exclude: true
 - **Cookie（くっきー）** … ブラウザがサーバーごとに保存する小さなメモ（ログイン状態などに使う）（[第2章](02-what-is-a-user.md)）
 - **localStorage（ろーかるすとれーじ）** … ブラウザに残しておける、自分用の保存箱（[第2章](02-what-is-a-user.md)）
 - **Supabaseクライアント（すぱべーすくらいあんと）** … アプリからSupabaseを呼び出すための部品（ライブラリ）（[第3章](03-first-data-save.md)）
-- **anon key（あのんきー）** … ブラウザに置いてよい公開用の鍵（RLSが守る前提）（[第4章](04-data-isolation.md)）
+- **Publishable key（ぱぶりっしゃぶるきー）** … ブラウザに置いてよい公開用の鍵（RLSが守る前提）。`sb_publishable_...` から始まる。以前は **anon key（あのんきー）** と呼ばれていた（[第4章](04-data-isolation.md)）
 - **service_role key（さーびすろーるきー）** … RLSを飛び越える強力な鍵（サーバーだけに置く、絶対に公開しない）（[第4章](04-data-isolation.md)）
 
 ---


### PR DESCRIPTION
## Summary
- 付録A（`apx-a-supabase-setup.md`）と用語集（`apx-e-glossary.md`）の「anon public key」表記を **Publishable key** に統一しました（計7箇所）。
- 背景: Supabase は2025年11月以降、新規プロジェクトでは legacy な anon key を発行せず、`sb_publishable_...` から始まる Publishable key を使う仕様に変更しています。そのため新規に手を動かす読者が「anon public key がどれか分からない」という詰まりが生じていました（Issue #89）。
- 「anon key」は旧称として、ことばメモ・用語集に説明を残しました（既存プロジェクトでは今もこの名称で表示されるため）。

参考:
- https://supabase.com/docs/guides/getting-started/api-keys
- https://github.com/orgs/supabase/discussions/29260

Fixes #89

## User Prompt
- 付録AのIssue（#89）が承認され、PR作成を依頼されたため対応。
- 修正方針は「本文は Publishable key に統一し、anon key は説明・用語としてのみ残す」でユーザーと合意。