### PR TITLE
docs: READMEに公式メディア・SNSリンク一覧を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 📖 **Web版（ドキュメントサイト）**: https://singularitysociety.github.io/societys_statement/
 
+## 公式メディア・SNS
+
+シンギュラリティ・ソサエティの情報発信は、ここからすべて辿れます。
+
+| メディア | リンク |
+| --- | --- |
+| 公式サイト | https://singularitysociety.org/ |
+| X（Twitter） | https://x.com/SingularitySoci |
+| YouTube | https://www.youtube.com/@SingularitySociety |
+| note | https://note.com/singsoc |
+
 ## 行動規範・カルチャー
 
 - [シンギュラリティ・ソサイエティ行動規範](./code-of-conduct.md)


### PR DESCRIPTION
## Summary

README.md（ドキュメントサイトの index）の冒頭に「公式メディア・SNS」の節を追加し、公式サイト・X（Twitter）・YouTube・note のリンクをまとめました。ここに来ればSSの情報発信をすべて辿れます。

## Items to Confirm / Review

- YouTube は公式サイトのフッターが載せている「若葉台コミュニティラジオ」（@wakabadai_radio）ではなく、SS 本体のチャンネル **@SingularitySociety** を採用しました。この選択でよいか
- Discord 招待リンク・GitHub org は指定になかったため未掲載（必要なら追加）

## User Prompt

> ここのindex(README.md)にSSのメディア情報をまとめたい。
> twitter web youtube noteの情報（リンク）をのせて、ここにくれば全部辿れるように。
> （確認として https://note.com/singsoc と https://www.youtube.com/@SingularitySociety の提示あり）

## Implementation

- README.md 冒頭（Web版リンク直後）に表形式で4リンクを追加
- リンクは全て実物を検証済み：
  - 公式サイト https://singularitysociety.org/ （フッターに各SNSリンクあり）
  - X https://x.com/SingularitySoci （公式サイトフッターから確認）
  - YouTube https://www.youtube.com/@SingularitySociety （チャンネル名 "Singularity Society" を確認）
  - note https://note.com/singsoc （公式アカウントであることを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)