### PR TITLE
docs: mcp_server の nav_order 衝突を解消（17 -> 18）

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -17,9 +17,9 @@ has_children: true
 - [コンピューティングの選択肢 — オンプレ/IaaS/コンテナ/PaaS/サーバーレス](./compute_options/README.md) — 「アプリをどこで動かすか」を AWS・Firebase・Vercel・Supabase など具体例で総合比較。用途・コスト・セキュリティ・長期メンテ・ベンダーロックイン・ペルソナ別（大企業/中堅/スタートアップ/個人）まで（初心者向け、全12ページ＋早見表/フローチャート/用語辞典）
 - [データの置き場所ガイド — RDB/NoSQL/キャッシュ/ストレージ](./data_stores/README.md) — 「データをどこに置くか」を RDB（SQLite/自前/RDS/Aurora）・NoSQL（DynamoDB/MongoDB/Firestore）・キャッシュ（Redis）・オブジェクトストレージ（S3系）で総合比較。データの形×運用の任せ方の2軸、ペルソナ別、選び方フローチャート・早見表・用語辞典つき（初心者向け、全12ページ＋ハブ。compute_options の姉妹編）
 - [フロントエンドの作り方 — 素のJS/React/Vue と SPA/SSR/SSG](./frontend/README.md) — 「UIをどう作り・どこで描画するか」を 素のTS/JS・React・Vue・SPA・SSR・SSG・Next.js/Astro（RSC=Reactの一部がバックエンド）まで総合比較。jQueryの歴史、ビルド（Vite）/ホスティング、ペルソナ/用途別、フローチャート・早見表・用語辞典つき（初心者向け、全12ページ＋ハブ。compute_options/data_stores の姉妹編）
-- [MCPサーバーを作って学ぶ AIに道具を持たせる入門](./mcp_server/README.md) — 「AIに道具を後付けする共通規格」MCP のサーバーとクライアントを自作。stdio と Streamable HTTP、`console.log` でサーバーが壊れる理由、MCP Inspector とログでの切り分け、パスの封じ込めと DNS リバインディング対策まで。TypeScript で「自分のメモを読める Claude」を作り、第2弾の ChatGPTクローンにも繋ぐ（完全未経験〜初心者向け、全14章＋付録A〜D）
 - [GitHub ActionsではじめるCI/CD](./github_actions/README.md) — 「安全に・自動で“届ける”」。CI/CDで何が嬉しいか、GitHub Actionsのしくみ（on→jobs→steps/YAML）、実例カタログ（テスト・CodeQL・レビューBot・Dependabot・デプロイ・リリース・cron・通知）、シークレットと安全、マトリクス/キャッシュ/コスト、選び方早見表・用語辞典つき（初心者向け、全8ページ＋ハブ。シリーズ姉妹編）
 - [AIハーネス入門 — AIに安全に良い仕事をさせる環境づくり](./harness/README.md) — 「口頭の注意」を「毎回自動で効く環境」に変える。CLAUDE.md の書き方（置き場所の使い分け・網羅的テンプレートつき）、lint とは何かから始める AI 向けガチガチ ESLint 設定（Vue/React + Express、MulmoClaude の実設定ベース、インストール手順つき）、subagent と CI 上の別AIによる cross review（判定マーカー・レビューループ運用）、フックと権限（破りようがない強制力）、Dependabot / CodeQL / CodeRabbit・CI codex レビュー実物解剖・レビュースキル2本の付録まで（実例つき、全4章＋付録3＋ハブ）
+- [MCPサーバーを作って学ぶ AIに道具を持たせる入門](./mcp_server/README.md) — 「AIに道具を後付けする共通規格」MCP のサーバーとクライアントを自作。stdio と Streamable HTTP、`console.log` でサーバーが壊れる理由、MCP Inspector とログでの切り分け、パスの封じ込めと DNS リバインディング対策まで。TypeScript で「自分のメモを読める Claude」を作り、第2弾の ChatGPTクローンにも繋ぐ（完全未経験〜初心者向け、全14章＋付録A〜D）
 - [Product Manageについて](./pm.md)
 - [Productについて](./Product.md)
 - [セキュリティ（攻撃の入口を知る教育ドキュメント）](./security/README.md)

--- a/development/mcp_server/README.md
+++ b/development/mcp_server/README.md
@@ -1,7 +1,7 @@
 ---
 title: "MCPサーバーを作って学ぶ AIに道具を持たせる入門"
 parent: "開発の心得"
-nav_order: 17
+nav_order: 18
 has_children: true
 has_toc: false
 ---


### PR DESCRIPTION
harness が nav_order 17 を使っており mcp_server と重複していたため 18 に繰り下げ。あわせて development/README.md の索引の並びをサイドバー順に統一。